### PR TITLE
Made $map protected and moved it to __construct()

### DIFF
--- a/Acl/Permission/BasicPermissionMap.php
+++ b/Acl/Permission/BasicPermissionMap.php
@@ -28,58 +28,63 @@ class BasicPermissionMap implements PermissionMapInterface
     const PERMISSION_MASTER      = 'MASTER';
     const PERMISSION_OWNER       = 'OWNER';
 
-    private $map = array(
-        self::PERMISSION_VIEW => array(
-            MaskBuilder::MASK_VIEW,
-            MaskBuilder::MASK_EDIT,
-            MaskBuilder::MASK_OPERATOR,
-            MaskBuilder::MASK_MASTER,
-            MaskBuilder::MASK_OWNER,
-        ),
+    protected $map = array();
 
-        self::PERMISSION_EDIT => array(
-            MaskBuilder::MASK_EDIT,
-            MaskBuilder::MASK_OPERATOR,
-            MaskBuilder::MASK_MASTER,
-            MaskBuilder::MASK_OWNER,
-        ),
-
-        self::PERMISSION_CREATE => array(
-            MaskBuilder::MASK_CREATE,
-            MaskBuilder::MASK_OPERATOR,
-            MaskBuilder::MASK_MASTER,
-            MaskBuilder::MASK_OWNER,
-        ),
-
-        self::PERMISSION_DELETE => array(
-            MaskBuilder::MASK_DELETE,
-            MaskBuilder::MASK_OPERATOR,
-            MaskBuilder::MASK_MASTER,
-            MaskBuilder::MASK_OWNER,
-        ),
-
-        self::PERMISSION_UNDELETE => array(
-            MaskBuilder::MASK_UNDELETE,
-            MaskBuilder::MASK_OPERATOR,
-            MaskBuilder::MASK_MASTER,
-            MaskBuilder::MASK_OWNER,
-        ),
-
-        self::PERMISSION_OPERATOR => array(
-            MaskBuilder::MASK_OPERATOR,
-            MaskBuilder::MASK_MASTER,
-            MaskBuilder::MASK_OWNER,
-        ),
-
-        self::PERMISSION_MASTER => array(
-            MaskBuilder::MASK_MASTER,
-            MaskBuilder::MASK_OWNER,
-        ),
-
-        self::PERMISSION_OWNER => array(
-            MaskBuilder::MASK_OWNER,
-        ),
-    );
+    public function __construct()
+    {
+        $this->map = array(
+            self::PERMISSION_VIEW => array(
+                MaskBuilder::MASK_VIEW,
+                MaskBuilder::MASK_EDIT,
+                MaskBuilder::MASK_OPERATOR,
+                MaskBuilder::MASK_MASTER,
+                MaskBuilder::MASK_OWNER,
+            ),
+    
+            self::PERMISSION_EDIT => array(
+                MaskBuilder::MASK_EDIT,
+                MaskBuilder::MASK_OPERATOR,
+                MaskBuilder::MASK_MASTER,
+                MaskBuilder::MASK_OWNER,
+            ),
+    
+            self::PERMISSION_CREATE => array(
+                MaskBuilder::MASK_CREATE,
+                MaskBuilder::MASK_OPERATOR,
+                MaskBuilder::MASK_MASTER,
+                MaskBuilder::MASK_OWNER,
+            ),
+    
+            self::PERMISSION_DELETE => array(
+                MaskBuilder::MASK_DELETE,
+                MaskBuilder::MASK_OPERATOR,
+                MaskBuilder::MASK_MASTER,
+                MaskBuilder::MASK_OWNER,
+            ),
+    
+            self::PERMISSION_UNDELETE => array(
+                MaskBuilder::MASK_UNDELETE,
+                MaskBuilder::MASK_OPERATOR,
+                MaskBuilder::MASK_MASTER,
+                MaskBuilder::MASK_OWNER,
+            ),
+    
+            self::PERMISSION_OPERATOR => array(
+                MaskBuilder::MASK_OPERATOR,
+                MaskBuilder::MASK_MASTER,
+                MaskBuilder::MASK_OWNER,
+            ),
+    
+            self::PERMISSION_MASTER => array(
+                MaskBuilder::MASK_MASTER,
+                MaskBuilder::MASK_OWNER,
+            ),
+    
+            self::PERMISSION_OWNER => array(
+                MaskBuilder::MASK_OWNER,
+            ),
+        );
+    }
 
     /**
      * {@inheritDoc}


### PR DESCRIPTION
By making $map protected and moving the actual declaration to the 
__construct, you make it easier to extend the BasicPermissionMap.

At the moment, if you want to extend it, you have to copy/paste the 
entire $map variable into your own class. I feel it makes more sense
to call the parent::__construct in your own mapping and add your own 
mappings to the variable, instead of having to replace it completely. 
