### PR TITLE
Fixed link to latest documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Resources
 
 Documentation:
 
-http://symfony.com/doc/2.4/book/security.html
+http://symfony.com/doc/current/book/security.html
 
 Resources
 ---------


### PR DESCRIPTION
The link to http://symfony.com/doc/2.4/book/security.html produces a 404 error.
