### PR TITLE
Moved exception message key to a constant.

### DIFF
--- a/Core/Exception/InvalidCsrfTokenException.php
+++ b/Core/Exception/InvalidCsrfTokenException.php
@@ -19,11 +19,13 @@ namespace Symfony\Component\Security\Core\Exception;
  */
 class InvalidCsrfTokenException extends AuthenticationException
 {
+    public const INVALID_CSRF_TOKEN = 'Invalid CSRF token.';
+    
     /**
      * {@inheritdoc}
      */
     public function getMessageKey()
     {
-        return 'Invalid CSRF token.';
+        return self::INVALID_CSRF_TOKEN;
     }
 }


### PR DESCRIPTION
We override the exception method in translation as users don't know what a CSRF token is, or why it is invalid. 
Using a public constant is more consistent for overriding in the translations.