### PR TITLE
Update documentation to let users know that the package is abandoned.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+# Important
+
+This package is abandoned and no longer maintained. Please use [Security Bundle](https://github.com/symfony/security-bundle) instead.
+
 Security Component
 ==================
 


### PR DESCRIPTION
We have the same message on packagist: https://packagist.org/packages/symfony/security

I am not sure if the new version is the [security bundle](https://github.com/symfony/security-bundle) or [this one](https://github.com/symfony/security-core)? 